### PR TITLE
DLS-9765 --[a11y] Table heading / caption [P2] -Move year h2 heading inside table caption

### DIFF
--- a/app/views/helpers/TransactionHistoryTabGenerator.scala
+++ b/app/views/helpers/TransactionHistoryTabGenerator.scala
@@ -37,13 +37,15 @@ class TransactionHistoryTabGenerator @Inject() (govukTable: GovukTable) {
     transactionHistoryForYears: Map[Int, List[TransactionHistoryItem]]
   )(implicit messages: Messages): Tabs = {
     val tabItems: Seq[TabItem] = transactionHistoryForYears.map { case (year, transactionHistoryItems) =>
-      val panelH2    = s"<h2 class=\"govuk-heading-m\">${year.toString}</h2>"
-      val panelTable = s"${govukTable(getTableHistoryForYear(transactionHistoryItems))}"
+      val tableHtml   = s"${govukTable(getTableHistoryForYear(transactionHistoryItems))}"
+      val captionHtml =
+        s"""<caption class="govuk-table__caption govuk-heading-m"><h2 class="govuk-heading-m">${year.toString}</h2></caption>"""
+      val panelTable = tableHtml.replace("<thead", s"$captionHtml<thead")
       TabItem(
         id = Some(s"year-${year.toString}"),
         label = year.toString,
         panel = TabPanel(
-          HtmlContent(s"$panelH2 $panelTable")
+          HtmlContent(panelTable)
         )
       )
     }.toSeq

--- a/it/testSupport/TransactionHistoryITHelper.scala
+++ b/it/testSupport/TransactionHistoryITHelper.scala
@@ -115,7 +115,8 @@ trait TransactionHistoryITHelper extends ControllerITTestHelper {
 
         val expectedPanelClassName = if(index == 0) {"govuk-tabs__panel"} else {"govuk-tabs__panel govuk-tabs__panel--hidden"}
         panel.className() mustBe expectedPanelClassName
-        panel.getElementsByClass("govuk-heading-m").text() mustBe year.toString
+        val caption = panel.getElementsByClass("govuk-table__caption").first()
+        caption.getElementsByTag("h2").text() mustBe year.toString
         val table = panel.getElementsByClass("govuk-table").first()
         val tableHeaders = table.getElementsByClass("govuk-table__header")
         tableHeaders.size() mustBe 5

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
   private val playVersion = s"-play-30"
   private val bootstrapVersion = "10.7.0"
   private val hmrcMongoVersion = "2.12.0"
-  private val playFrontendHMRCVersion = "13.7.0"
+  private val playFrontendHMRCVersion = "13.8.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/test/views/TransactionHistoryViewSpec.scala
+++ b/test/views/TransactionHistoryViewSpec.scala
@@ -108,8 +108,9 @@ class TransactionHistoryViewSpec extends TransactionHistoryViewHelper {
                   panel.className() mustBe expectedPanelClassName
                 }
 
-                "which includes a heading with the year " in {
-                  panel.getElementsByClass("govuk-heading-m").text() mustBe year.toString
+                "which includes a table caption with the year heading" in {
+                  val caption = panel.getElementsByClass("govuk-table__caption").first()
+                  caption.getElementsByTag("h2").text() mustBe year.toString
                 }
 
                 "which includes a table" - {


### PR DESCRIPTION
The transaction history tables now wrap the existing h2 year heading inside a <caption> element, allowing screen-reader users to navigate tables by caption